### PR TITLE
ZXing 3.3.2 snapshot still creates wrong barcode for text with leadin…

### DIFF
--- a/core/src/main/java/com/google/zxing/datamatrix/encoder/EdifactEncoder.java
+++ b/core/src/main/java/com/google/zxing/datamatrix/encoder/EdifactEncoder.java
@@ -66,6 +66,11 @@ final class EdifactEncoder implements Encoder {
         context.updateSymbolInfo();
         int available = context.getSymbolInfo().getDataCapacity() - context.getCodewordCount();
         int remaining = context.getRemainingCharacters();
+        // The following two lines are a hack inspired by the 'fix' from https://sourceforge.net/p/barcode4j/svn/221/
+        if (remaining > available) {
+          context.updateSymbolInfo(context.getCodewordCount() + 1);
+          available = context.getSymbolInfo().getDataCapacity() - context.getCodewordCount();
+        }
         if (remaining <= available && available <= 2) {
           return; //No unlatch
         }


### PR DESCRIPTION
…… (#967)

* ZXing 3.3.2 snapshot still creates wrong barcode for text with leading asterisk #960

* missing spaces